### PR TITLE
Fixed incorrect parameters for Mage_Core_Exception

### DIFF
--- a/src/lib/Diglin/Io/File.php
+++ b/src/lib/Diglin/Io/File.php
@@ -48,11 +48,11 @@ class Diglin_Io_File extends Varien_Io_File{
 
         if (file_exists($filename)) {
             if (!is_writeable($filename)) {
-                throw new Mage_Core_Exception('File %s don\'t writeable', $filename);
+                throw new Mage_Core_Exception("File $filename is not writeable");
             }
         } else {
             if (!is_writable(dirname($filename))) {
-                throw new Mage_Core_Exception('Folder %s don\'t writeable', $filename);
+                throw new Mage_Core_Exception("Folder $filename is not writeable");
             }
         }
         if ($srcIsFile) {


### PR DESCRIPTION
The creation of the Mage_Core_Exception instances were passing an invalid second parameter.  I fixed this and fixed the wording.